### PR TITLE
Fix for error messages about automate_workspace.

### DIFF
--- a/library/manageiq_automate.py
+++ b/library/manageiq_automate.py
@@ -69,8 +69,9 @@ class ManageIQAutomate(object):
             The url to connect to the workspace
         """
         url_str = self._module.params['manageiq_connection']['automate_workspace']
+        if url_str is None:
+            self._module.fail_json(msg='Required parameter \'automate_workspace\' is not specified')
         return self._api_url + '/' + url_str
-
 
     def href_slug_url(self, value):
         """
@@ -90,6 +91,8 @@ class ManageIQAutomate(object):
             url = self.url()
 
         result, _info = fetch_url(self._module, url, None, self._headers, 'get')
+        if result is None
+            self._module.fail_json(msg=_info['msg'])   
         return json.loads(result.read())
 
 


### PR DESCRIPTION
 Fixing error messages for requests with missing or invalid `automate_workspace`.

Steps to reproduce:
1) Create ansible-playbook with invalid or missing parameter `automate_workspace`
2) Call the playbook from terminal via `ansible-playbook` 
    * example: `ansible-playbook ~/playbook.yaml`