### PR TITLE
Wrap all values in quotes for the exists method

### DIFF
--- a/library/manageiq_automate.py
+++ b/library/manageiq_automate.py
@@ -92,7 +92,7 @@ class ManageIQAutomate(object):
 
         result, _info = fetch_url(self._module, url, None, self._headers, 'get')
         if result is None:
-            self._module.fail_json(msg=_info['msg'])   
+            self._module.fail_json(msg=_info['msg'])
         return json.loads(result.read())
 
 
@@ -126,10 +126,16 @@ class ManageIQAutomate(object):
     def exists(self, path):
         """
             Validate all passed objects before attempting to set or get values from them
+
+            Wrap all reduced values in quotes so the bool() method will not
+            return a False on falsey values
         """
         list_path = path.split("|")
+        str = None
         try:
-            return bool(reduce(operator.getitem, list_path, self._target))
+            reduced_str = reduce(operator.getitem, list_path, self._target)
+            str = "%s" % (reduced_str)
+            return bool(str)
         except KeyError as error:
             return False
 


### PR DESCRIPTION
This resolves an issue where the `bool()` method returned false for falsey values returned on a key
Moving forward we still allow False returned on a `KeyError` but if the key exists we wrap the value
in quotes so the bool response will resolve to the correct answer of True