### PR TITLE
Allow for nulls in the exists method

### DIFF
--- a/library/manageiq_automate.py
+++ b/library/manageiq_automate.py
@@ -123,19 +123,19 @@ class ManageIQAutomate(object):
         return  json.loads(result.read())
 
 
-    def exists(self, path):
+    def exists(self, path, allow_null=False):
         """
-            Validate all passed objects before attempting to set or get values from them
+            Validate via bool() all passed objects before attempting to set or get values from them
 
-            Wrap all reduced values in quotes so the bool() method will not
-            return a False on falsey values
+            If allow_null is true then return True or fail on a KeyError
         """
         list_path = path.split("|")
-        str = None
+
         try:
             reduced_str = functools.reduce(operator.getitem, list_path, self._target)
-            str = "%s" % (reduced_str)
-            return bool(str)
+            if allow_null and not reduced_str:
+                return True
+            return bool(reduced_str)
         except KeyError as error:
             return False
 
@@ -197,7 +197,7 @@ class Workspace(ManageIQAutomate):
         attribute = dict_options['attribute']
         path = "workspace|input|objects"
         search_path = "|".join([path, obj, attribute])
-        if self.exists(search_path):
+        if self.exists(search_path, True):
             return dict(changed=False, value=True)
         return dict(changed=False, value=False)
 


### PR DESCRIPTION
If the allow_null argument is true we now allow any result
to return as true. This nullifies the bool() check
So seems bad, but in some cases when an attribute exists
When looking up 'get_object_attribute_names' we want
the value of that attribute even if it is null
In the case of an allow_null then only a KeyError
will return False